### PR TITLE
convert lineage from string to list of dicts format in package_dict

### DIFF
--- a/ckanext/cioos_harvest/plugin.py
+++ b/ckanext/cioos_harvest/plugin.py
@@ -729,8 +729,21 @@ class Cioos_HarvestPlugin(plugins.SingletonPlugin):
             # populate datacentre
             package_dict['datacentre'] = iso_values.get('keyword-datacentre', [])
 
-            # populate lineage
-            package_dict['lineage'] = iso_values.get('lineage',[])
+            # populate lineage - convert string to list of dicts as required by schema
+            lineage_value = iso_values.get('lineage', [])
+            if isinstance(lineage_value, str):
+                # Convert string lineage to required list of dicts format
+                log.warning('Converting lineage from string to list of dicts for dataset: %s',
+                           iso_values.get('guid', 'unknown'))
+                package_dict['lineage'] = [{
+                    'statment': {'en': lineage_value},
+                    'scope': 'dataset',
+                    'additional-documentation': [],
+                    'source': [],
+                    'processing-step': []
+                }]
+            else:
+                package_dict['lineage'] = lineage_value if lineage_value else []
 
             # populate publishing data catalogue list
             package_dict['included_in_data_catalogue'] = [{


### PR DESCRIPTION
This pull request improves the handling of the `lineage` field in the `get_package_dict` method to ensure it matches the required schema. Now, if the `lineage` value is provided as a string, it is converted into a list of dictionaries with the appropriate structure, and a warning is logged to help track such conversions.

**Data transformation improvements:**

* Updated the `lineage` field in `get_package_dict` to convert string values into the required list-of-dicts format, logging a warning when this conversion occurs. This ensures compatibility with the expected schema and improves data consistency.